### PR TITLE
Move PHP Exclusion out of the rules

### DIFF
--- a/Template.php
+++ b/Template.php
@@ -115,7 +115,7 @@ class Template {
         $this->rules[] = new Rule(
             'if_boolean', 
             '~\{if:(\w+)\}~', 
-            '<?php if ($this->data[\'$1\']): ?>'
+            '<?php if (isset($this->data[\'$1\']) && $this->data[\'$1\']): ?>'
         );
         $this->rules[] = new Rule(
         		'if_condition',
@@ -137,7 +137,7 @@ class Template {
         $this->rules[] = new Rule(
             'elseif_boolean', 
             '~\{else:(\w+)\}~', 
-            '<?php elseif ($this->data[\'$1\']): ?>'
+            '<?php elseif (isset($this->data[\'$1\']) && $this->data[\'$1\']): ?>'
         );
         $this->rules[] = new Rule(
             'elseif_condition', 


### PR DESCRIPTION
Having PHP Exclusion in the rules caused many parsing errors especially when using imported files. To fix that I moved it to the constructor of the class, cleaning the file on loading.

I also change the regex for the import path and made it possible to specify an include path for the import function because the import in including from the library's directory. This new feature adds a new method to the class named "set_include_path".
