### PR TITLE
Move Delimiters Out of Rule Definitions

### DIFF
--- a/Layout.php
+++ b/Layout.php
@@ -11,7 +11,7 @@ class Layout extends Template {
 	public function process(array $custom_rules, array $data) {
 		$custom_rules[] = new Rule(
 				'yield',
-				'~\{yield\}~',
+				'yield',
 				'<?php $end = end($this->data); echo $end; ?>'
 		);
 		

--- a/Template.php
+++ b/Template.php
@@ -117,34 +117,34 @@ class Template {
         // If conditionning
         $this->rules[] = new Rule(
             'if_boolean', 
-            '~\{if:(\w+)\}~', 
+            'if:(\w+)', 
             '<?php if (isset($this->data[\'$1\']) && $this->data[\'$1\']): ?>'
         );
         $this->rules[] = new Rule(
         		'if_condition',
-        		'~\{if:(\w+)([!<>=]+)(\w+)\}~',
+        		'if:(\w+)([!<>=]+)(\w+)',
         		'<?php if (isset($this->data[\'$1\'])){$base = $this->data[\'$1\'];}else{$base = \'$1\';};
         		if (isset($this->data[\'$3\'])){$value = $this->data[\'$3\'];}else{$value = \'$3\';}?>
         		<?php if ($base $2 $value): ?>'
         );
         $this->rules[] = new Rule(
             'ifnot', 
-            '~\{ifnot:(\w+)\}~', 
+            'ifnot:(\w+)', 
             '<?php if (!$this->data[\'$1\']): ?>'
         );
         $this->rules[] = new Rule(
             'else', 
-            '~\{else\}~', 
+            'else', 
             '<?php else: ?>'
         );
         $this->rules[] = new Rule(
             'elseif_boolean', 
-            '~\{else:(\w+)\}~', 
+            'else:(\w+)', 
             '<?php elseif (isset($this->data[\'$1\']) && $this->data[\'$1\']): ?>'
         );
         $this->rules[] = new Rule(
             'elseif_condition', 
-            '~\{else:(\w+)([!<>=]+)(\w+)\}~', 
+            'else:(\w+)([!<>=]+)(\w+)', 
             '<?php elseif (((isset($this->data[\'$1\']) && isset($this->data[\'$3\'])) && $this->data[\'$1\'] $2 $this->data[\'$3\']) ||
         		((isset($this->data[\'$1\']) && !isset($this->data[\'$3\'])) && $this->data[\'$1\'] $2 \'$3\') ||
         		((!isset($this->data[\'$1\']) && isset($this->data[\'$3\'])) && \'$1\' $2 $this->data[\'$3\']) ||
@@ -152,33 +152,33 @@ class Template {
         );
         $this->rules[] = new Rule(
             'endif', 
-            '~\{endif\}~', 
+            'endif', 
             '<?php endif; ?>'
         );
         
         // Loops
         $this->rules[] = new Rule(
             'loop', 
-            '~\{loop:(\w+)\}~', 
+            'loop:(\w+)', 
             '<?php foreach ($this->data[\'$1\'] as $element): $this->wrap($element); ?>'
         );
         $this->rules[] = new Rule(
             'endloop', 
-            '~\{endloop\}~', 
+            'endloop', 
             '<?php $this->unwrap(); endforeach; ?>'
         );
         
         // Importing
         $this->rules[] = new Rule(
             'import_view', 
-            '~\{import:(([^\/\s]+\/)?(.*))\}~', 
+            'import:(([^\/\s]+\/)?(.*))', 
             '<?php echo $this->importFile(\'$1\'); ?>'
         );
         
         // Clean variables
         $this->rules[] = new Rule(
             'escape_var', 
-            '~\{escape:(\w+)\}~', 
+            'escape:(\w+)', 
             '<?php $this->showVariable(\'$1\', true); ?>'
         );
         
@@ -188,20 +188,20 @@ class Template {
         // Variables
         $this->rules[] = new Rule(
             'variable', 
-            '~\{(\w+)\}~', 
+            '(\w+)', 
             '<?php $this->showVariable(\'$1\'); ?>'
         );
         
         // Arrays
         $this->rules[] = new Rule(
         		'variable_array',
-        		'~\{(\w+)\[(\w+)\]\}~',
+        		'(\w+)\[(\w+)\]',
         		'<?php echo (isset($this->data[\'$1\'][\'$2\'])) ? $this->data[\'$1\'][\'$2\'] : "&#123;$1[$2]&#125"; ?>'
         );
         
         $this->rules[] = new Rule(
         		'variable_array_escape',
-        		'~\{escape:(\w+)\[(\w+)\]\}~',
+        		'escape:(\w+)\[(\w+)\]',
         		'<?php echo htmlentities($this->showVariable(\'$1\')[\'$2\']); ?>'
         );
         
@@ -209,7 +209,7 @@ class Template {
         $this->stack = array();
         
         foreach ($this->rules as $rule) {
-            $this->template = preg_replace($rule->rule(), $rule->replacement(), $this->template);
+            $this->template = preg_replace('/\{' . $rule->rule() . '\}/', $rule->replacement(), $this->template);
         }
         
         $this->template = '?>' . $this->template;

--- a/test/index.php
+++ b/test/index.php
@@ -14,7 +14,7 @@ class Application {
         $time = microtime(true);
         Engine::instance()->add_rule(new Rule(
                 'translate', 
-                '~\{translate:(\w+),(\w+)\}~', 
+                'translate:(\w+),(\w+)', 
                 '<?php \\Application::translate(\'$1\', \'$2\'); ?>'));
         Engine::instance()->add_data(array(
             "working" => "&#10003;",

--- a/test/test.htm
+++ b/test/test.htm
@@ -57,7 +57,7 @@
 	<span>{working}</span>
     {endif}
     <code>
-        &#123;if:variable>value)&#123;endif}<br>
+        &#123;if:variable>value}&#123;endif}<br>
     </code>
 </div>
 <div>
@@ -66,7 +66,7 @@
 	<span>{working}</span>
     {endif}
     <code>
-        &#123;if:variable&lt;value)&#123;endif}<br>
+        &#123;if:variable&lt;value}&#123;endif}<br>
     </code>
 </div>
 <div>
@@ -75,7 +75,7 @@
 	<span>{working}</span>
     {endif}
     <code>
-        &#123;if:variable>=value)&#123;endif}<br>
+        &#123;if:variable>=value}&#123;endif}<br>
     </code>
 </div>
 <div>
@@ -84,7 +84,7 @@
 	<span>{working}</span>
     {endif}
     <code>
-        &#123;if:variable&lt;=value)&#123;endif}<br>
+        &#123;if:variable&lt;=value}&#123;endif}<br>
     </code>
 </div>
 <div>
@@ -93,7 +93,7 @@
 	<span>{working}</span>
     {endif}
     <code>
-        &#123;if:variable==value)&#123;endif}<br>
+        &#123;if:variable==value}&#123;endif}<br>
     </code>
 </div>
 <div>
@@ -102,7 +102,7 @@
 	<span>{working}</span>
     {endif}
     <code>
-        &#123;if:variable!=value)&#123;endif}<br>
+        &#123;if:variable!=value}&#123;endif}<br>
     </code>
 </div>
 <div>


### PR DESCRIPTION
I moved delimiters out of rule definitions. This will make custom rules easier to create for users because they won't have to write these themselves.

And maybe, we could add the possibility to change these default delimiters as a new feature later?
